### PR TITLE
add command line arguments for choosing API version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV WATCHTOWER_BRANCH master
 ENV GOPATH /usr/local
 
 RUN apk add --no-cache --virtual build-dependencies build-base go git && \
-  git clone -b ${WATCHTOWER_BRANCH} ${WATCHTOWER_REPO} /usr/local/src/${WATCHTOWER_PATH} && \
+  git clone --depth=1 -b ${WATCHTOWER_BRANCH} ${WATCHTOWER_REPO} /usr/local/src/${WATCHTOWER_PATH} && \
   cd /usr/local/src/${WATCHTOWER_PATH} && \
   go get ./... && \
   go install ${WATCHTOWER_PATH}... && \

--- a/rootfs/etc/s6/watchtower/run
+++ b/rootfs/etc/s6/watchtower/run
@@ -18,4 +18,4 @@ STARTCMD="/usr/bin/watchtower"
 [[ -n "${WATCHTOWER_TLS_CERT}" ]] && STARTCMD="${STARTCMD} -tlscert=${WATCHTOWER_TLS_CERT}"
 [[ -n "${WATCHTOWER_TLS_KEY}" ]] && STARTCMD="${STARTCMD} -tlskey=${WATCHTOWER_TLS_KEY}"
 
-exec ${STARTCMD}
+exec ${STARTCMD} ${CMD_ARGUMENTS}


### PR DESCRIPTION
watchtower would require 1.26, but only 1.24 is stable on docker-engine 1.12
took ideas from just-containers/s6-overlay#102 (comment)

can be invoked like

    docker run -d --name watchtower -v /var/run/docker.sock:/var/run/docker.sock -e CMD_ARGUMENTS="--apiversion 1.24" allmende/watchtower:latest